### PR TITLE
fix: ignore empty selector to avoid restarting all pods

### DIFF
--- a/kubectl-renew
+++ b/kubectl-renew
@@ -27,7 +27,11 @@ case $KIND in
 		renew_pod "$NAME" ;;
 	deployment|daemonset|rc)
 		selector=$(kubectl get "$KIND" "$NAME" -n "$NS" --output=json | jq -j '.spec.selector.matchLabels | to_entries | .[] | "\(.key)=\(.value),"')
+		if [ -z "$selector"]; then
+			exit 1;
+		fi
 		pods=$(kubectl get pods -n "$NS" --selector="${selector%?}" --output=jsonpath={.items..metadata.name})
+
 		for pod in $pods; do
 			renew_pod "$pod"
 		done ;;


### PR DESCRIPTION
set -e is being used to force the script to stop when an error occur.
This seems to not be working when running commands inside a subshell,
which causes the restart of all pods in that namespace.

This is a serious bug and if I was not quick enough or ran the command
in an unsuppervised manner it would restart all our services in production :(.